### PR TITLE
Allow opengl overrides

### DIFF
--- a/src/nep_config.cpp
+++ b/src/nep_config.cpp
@@ -104,6 +104,7 @@ void NepConfig::loadDefault() {
 	setOption<bool, NEP_BOOL>("Enable VSync control", NULL, true);
 	setOption<bool, NEP_BOOL>("Enable texture compression", NULL, true);
 	setOption<bool, NEP_BOOL>("Enable memory optimization", NULL, true);
+	setOption<const char*, NEP_STRING>("Override opengl dll name", "Load this instead of opengl32.dll. If it doesn't exist normal behavior will be used", "opengl32_nep.dll");
 	updateTxt();
 }
 

--- a/src/opengl_proxy.cpp
+++ b/src/opengl_proxy.cpp
@@ -26,6 +26,7 @@
 #include <cstdlib>
 #include <ctime>
 #include "nep_main.h"
+#include "nep_config.h"
 
 // ========================================================
 // GLProxy utilities:
@@ -112,6 +113,19 @@ public:
             fatalError("Real OpenGL DLL is already loaded!");
         }
 
+        const char* override = nepCfg.gets("Override opengl dll name");
+        if (override && override[0])
+        {
+            NEP_LOGV("Override enabled\n");
+            dllHandle = LoadLibraryA(override);
+
+            if (dllHandle)
+            {
+                NEP_LOGI("Using %s instead of opengl32.dll\n", override);
+                return;
+            }
+        }
+
         const auto glDllFilePath = getRealGLLibPath();
 
         dllHandle = LoadLibraryExA(glDllFilePath.c_str(), nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
@@ -125,6 +139,8 @@ public:
         {
             fatalError("GLProxy trying to load itself as the real opengl32.dll!");
         }
+
+        NEP_LOGI("Using system's opengl32.dll\n");
     }
 
     void unload()


### PR DESCRIPTION
Allow opengl overrides. Name is hardcoded to `opengl32_nep.dll` due to config system limitations.

You can get mesa variants from here: <https://github.com/mmozeiko/build-mesa>. D3D12 ([24.3.4](https://github.com/mmozeiko/build-mesa/releases/tag/24.3.4)) fixes flickering on NVIDIA RTX 3060 from my limited testing. Starting from mesa 25, shader compiler has issues allocating registers and game crashes even with `D3D12_DEBUG=experimental` in release, but not in debug?